### PR TITLE
Fix: removing duplicate text-decoration style for abbr[title] #33197

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -142,7 +142,6 @@ p {
 
 abbr[title],
 abbr[data-bs-original-title] { // 1
-  text-decoration: underline; // 2
   text-decoration: underline dotted; // 2
   cursor: help; // 3
   text-decoration-skip-ink: none; // 4


### PR DESCRIPTION
Removing duplicate text-decoration style for abbr[title] #33197